### PR TITLE
Grid: keep the scrollbar custom element out of tree-shaking

### DIFF
--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -23,7 +23,8 @@
   ],
   "type": "module",
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "**/sv-grid-scrollbar.*"
   ],
   "types": "dist/index.d.ts",
   "module": "dist/index.js",


### PR DESCRIPTION
`sideEffects: ["**/*.css"]` told bundlers every JS module in the package is pure. sv-grid-scrollbar.ts is the opposite: it has no exports at all (`export {}`) and exists solely to run

    customElements.define('sv-grid-scrollbar', SvGridScrollbarElement)

so the 15 bare `import "./sv-grid-scrollbar"` statements were free to be dropped. Every production build did drop it. The grid still emitted both <sv-grid-scrollbar> elements with correct geometry, but with the element unregistered they never upgraded - no shadow root, nothing painted - and because the container always carries sv-grid-container-custom-scrollbars (scrollbar-width: none) the native scrollbars were suppressed too. Result was a scrollable grid with no scrollbars at all, in every bundled app. Dev builds were fine because vite dev does not tree-shake, which is why this survived so long.

The glob covers both resolutions: consumers of the published package get dist/sv-grid-scrollbar.js, while the website aliases @svgrid/grid to packages/grid/src and gets the .ts.

Verified in a browser against a production build: customElements.get() goes undefined -> defined, both scrollbars upgraded false -> true, and computed display block (inert unknown tag) -> flex.